### PR TITLE
Keep existing array intact while updating itemOrder

### DIFF
--- a/OrderedItems/OrderedItems.cs
+++ b/OrderedItems/OrderedItems.cs
@@ -70,7 +70,9 @@ namespace OrderedItems
             {
                 ItemSorter.SortItems(inventory, self, out int[] itemStacks, out ItemIndex[] itemOrder);
                 CachedReflection.ItemStacksField.SetValue(self, itemStacks);
-                CachedReflection.ItemOrderField.SetValue(self, itemOrder);
+                var existingOrder = (ItemIndex[])CachedReflection.ItemOrderField.GetValue(self);
+                itemOrder.CopyTo(existingOrder, 0);
+                CachedReflection.ItemOrderField.SetValue(self, existingOrder);
                 CachedReflection.ItemOrderCountField.SetValue(self, itemOrder.Length);
             }
 


### PR DESCRIPTION
Bandaid patch for #2 (and possibly #1). It's likely possible to optimize some of the structure of ItemSorter around this change, and using a publicized Assembly-Csharp.dll reference could get rid of a lot of the reflection involved in this mod... but, for now, this will at least stop one known mod conflict (tested it to make sure) and probably a few unknown ones.